### PR TITLE
Extend compatibility through Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py311']
+target-version = ['py35', 'py36', 'py37', 'py38', 'py39', 'py310', 'py311']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 120
-target-version = ['py35']
+target-version = ['py311']

--- a/t2i/__init__.py
+++ b/t2i/__init__.py
@@ -4,7 +4,11 @@ Originally based on the `diagnnose <https://github.com/i-machine-think/diagnnose
 """
 
 import codecs
-from collections import Counter, Iterable as IterableClass  # Distinguish from typing.Iterable
+from collections import Counter
+try:
+    from collections import Iterable as IterableClass  # Distinguish from typing.Iterable
+except ImportError:
+    from collections.abc import Iterable as IterableClass  # Distinguish from typing.Iterable
 import sys
 import pickle
 from typing import Dict, Union, Iterable, Optional, Any, Hashable, Tuple, Iterator


### PR DESCRIPTION
Fixes import of Iterable abstract base class on Python 3.10 and later; sets the target versions to include 3.5 through 3.11 which is the default Python on Debian stable at the moment.